### PR TITLE
feat(blog-avatar): add blog-avatar component

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
     "./antd": {
       "types": "./dist/antd/index.d.ts",
       "import": "./dist/antd/index.js"
+    },
+    "./blog-avatar": {
+      "types": "./dist/blog-avatar/index.d.ts",
+      "import": "./dist/blog-avatar/index.js"
     }
   },
   "repository": {

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
         entry: {
           'nav-icon': './src/nav-icon/index.tsx',
           benchmark: './src/benchmark/index.tsx',
+          'blog-avatar': './src/blog-avatar/index.tsx',
           'tool-stack': './src/tool-stack/index.tsx',
           hero: './src/hero/index.tsx',
           'section-style': './src/section-style/index.tsx',

--- a/src/blog-avatar/index.module.scss
+++ b/src/blog-avatar/index.module.scss
@@ -1,0 +1,187 @@
+:global {
+  html:not(.dark) {
+    --rs-blog-avatar-link-hover-bg: rgba(249, 57, 32, 0.08);
+    --rs-blog-avatar-group-ring: rgba(255, 255, 255, 0.92);
+    --rs-blog-avatar-group-overflow-bg: var(--rp-c-bg-soft);
+  }
+
+  html.dark {
+    --rs-blog-avatar-link-hover-bg: rgba(255, 112, 77, 0.14);
+    --rs-blog-avatar-group-ring: #111827;
+    --rs-blog-avatar-group-overflow-bg: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.root {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 100%;
+  padding: 4px 0;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  pointer-events: none;
+  box-shadow: 0 0 0 1px rgba(143, 161, 185, 0.18);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 2px;
+}
+
+.nameRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.name {
+  color: var(--rp-c-text-1);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.title {
+  color: var(--rp-c-text-2);
+  font-size: 0.75rem;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--rp-c-text-2);
+  opacity: 0.55;
+  transition:
+    opacity 0.2s ease,
+    color 0.2s ease;
+}
+
+.root:hover .links,
+.root:focus-within .links {
+  opacity: 1;
+}
+
+.link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  color: inherit;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--rp-c-brand);
+    background-color: var(--rs-blog-avatar-link-hover-bg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-c-brand);
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 12px;
+    height: 12px;
+  }
+}
+
+.group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 20px;
+  max-width: 100%;
+}
+
+.groupItem {
+  max-width: 100%;
+}
+
+.compactGroup {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.compactAvatars {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.compactAvatar,
+.compactOverflow {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px var(--rs-blog-avatar-group-ring);
+}
+
+.compactAvatar {
+  object-fit: cover;
+  background-color: var(--rp-c-bg-soft);
+}
+
+.compactAvatar + .compactAvatar,
+.compactOverflow {
+  margin-left: -8px;
+}
+
+.compactOverflow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--rp-c-text-1);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  background-color: var(--rs-blog-avatar-group-overflow-bg);
+}
+
+.compactNames {
+  min-width: 0;
+  color: var(--rp-c-text-2);
+  font-size: 0.875rem;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 768px) {
+  .group {
+    gap: 10px 16px;
+  }
+
+  .compactGroup {
+    gap: 8px;
+  }
+
+  .compactNames {
+    font-size: 0.8125rem;
+  }
+}

--- a/src/blog-avatar/index.module.scss
+++ b/src/blog-avatar/index.module.scss
@@ -1,12 +1,10 @@
 :global {
   html:not(.dark) {
-    --rs-blog-avatar-link-hover-bg: rgba(249, 57, 32, 0.08);
     --rs-blog-avatar-group-ring: rgba(255, 255, 255, 0.92);
     --rs-blog-avatar-group-overflow-bg: var(--rp-c-bg-soft);
   }
 
   html.dark {
-    --rs-blog-avatar-link-hover-bg: rgba(255, 112, 77, 0.14);
     --rs-blog-avatar-group-ring: #111827;
     --rs-blog-avatar-group-overflow-bg: rgba(255, 255, 255, 0.08);
   }
@@ -93,12 +91,11 @@
 
   &:hover,
   &:focus-visible {
-    color: var(--rp-c-brand);
-    background-color: var(--rs-blog-avatar-link-hover-bg);
+    color: var(--rp-c-text-1);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--rp-c-brand);
+    outline: 2px solid var(--rp-c-text-1);
     outline-offset: 2px;
   }
 

--- a/src/blog-avatar/index.tsx
+++ b/src/blog-avatar/index.tsx
@@ -1,0 +1,176 @@
+import type { ReactNode } from 'react';
+import styles from './index.module.scss';
+
+const MAX_VISIBLE_COMPACT_AUTHORS = 3;
+
+export type BlogAvatarLink = {
+  href: string;
+  label: string;
+  icon: ReactNode;
+};
+
+export type BlogAvatarAuthor = {
+  name: string;
+  avatar: string;
+  title?: string;
+  github?: string;
+  x?: string;
+  links?: BlogAvatarLink[];
+};
+
+export type BlogAvatarProps = {
+  author: BlogAvatarAuthor;
+  className?: string;
+};
+
+export type BlogAvatarGroupProps = {
+  authors: BlogAvatarAuthor[];
+  className?: string;
+  compact?: boolean;
+};
+
+const getClassName = (...classNames: Array<string | false | undefined>) => {
+  return classNames.filter(Boolean).join(' ');
+};
+
+const getAuthorKey = (author: BlogAvatarAuthor) => {
+  return `${author.name}-${author.github ?? author.x ?? author.avatar}`;
+};
+
+const GitHubIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path
+      fill="currentColor"
+      d="M12 .297c-6.63 0-12 5.373-12 12c0 5.303 3.438 9.8 8.205 11.385c.6.113.82-.258.82-.577c0-.285-.01-1.04-.015-2.04c-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729c1.205.084 1.838 1.236 1.838 1.236c1.07 1.835 2.809 1.305 3.495.998c.108-.776.417-1.305.76-1.605c-2.665-.3-5.466-1.332-5.466-5.93c0-1.31.465-2.38 1.235-3.22c-.135-.303-.54-1.523.105-3.176c0 0 1.005-.322 3.3 1.23c.96-.267 1.98-.399 3-.405c1.02.006 2.04.138 3 .405c2.28-1.552 3.285-1.23 3.285-1.23c.645 1.653.24 2.873.12 3.176c.765.84 1.23 1.91 1.23 3.22c0 4.61-2.805 5.625-5.475 5.92c.42.36.81 1.096.81 2.22c0 1.606-.015 2.896-.015 3.286c0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+    />
+  </svg>
+);
+
+const XIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path
+      fill="currentColor"
+      d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584l-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"
+    />
+  </svg>
+);
+
+const getSocialLinks = ({
+  github,
+  links,
+  name,
+  x,
+}: BlogAvatarAuthor): BlogAvatarLink[] => {
+  return [
+    ...(github
+      ? [
+          {
+            href: github,
+            label: `${name}'s GitHub`,
+            icon: <GitHubIcon />,
+          },
+        ]
+      : []),
+    ...(x
+      ? [
+          {
+            href: x,
+            label: `${name}'s X profile`,
+            icon: <XIcon />,
+          },
+        ]
+      : []),
+    ...(links ?? []),
+  ];
+};
+
+export function BlogAvatar({ author, className }: BlogAvatarProps) {
+  const { avatar, name, title } = author;
+  const socialLinks = getSocialLinks(author);
+
+  return (
+    <div className={getClassName(styles.root, className)}>
+      <img
+        src={avatar}
+        alt={name}
+        className={styles.avatar}
+        loading="lazy"
+        decoding="async"
+      />
+      <div className={styles.content}>
+        <div className={styles.nameRow}>
+          <div className={styles.name}>{name}</div>
+          {socialLinks.length > 0 ? (
+            <div className={styles.links}>
+              {socialLinks.map(link => (
+                <a
+                  href={link.href}
+                  key={`${link.label}-${link.href}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.link}
+                  aria-label={link.label}
+                >
+                  {link.icon}
+                </a>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        {title ? <div className={styles.title}>{title}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+export function BlogAvatarGroup({
+  authors,
+  className,
+  compact = false,
+}: BlogAvatarGroupProps) {
+  if (authors.length === 0) {
+    return null;
+  }
+
+  if (!compact) {
+    return (
+      <div className={getClassName(styles.group, className)}>
+        {authors.map(author => (
+          <BlogAvatar
+            author={author}
+            className={styles.groupItem}
+            key={getAuthorKey(author)}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const visibleAuthors = authors.slice(0, MAX_VISIBLE_COMPACT_AUTHORS);
+  const overflowCount = authors.length - visibleAuthors.length;
+  const authorNames = authors.map(author => author.name).join(', ');
+
+  return (
+    <div
+      className={getClassName(styles.compactGroup, className)}
+      title={authorNames}
+    >
+      <div className={styles.compactAvatars} aria-hidden="true">
+        {visibleAuthors.map(author => (
+          <img
+            src={author.avatar}
+            alt=""
+            className={styles.compactAvatar}
+            loading="lazy"
+            decoding="async"
+            key={getAuthorKey(author)}
+          />
+        ))}
+        {overflowCount > 0 ? (
+          <span className={styles.compactOverflow}>+{overflowCount}</span>
+        ) : null}
+      </div>
+      <div className={styles.compactNames}>{authorNames}</div>
+    </div>
+  );
+}

--- a/stories/BlogAvatar.stories.tsx
+++ b/stories/BlogAvatar.stories.tsx
@@ -1,0 +1,52 @@
+import { BlogAvatar, BlogAvatarGroup } from '@rstack-dev/doc-ui/blog-avatar';
+import './index.scss';
+
+const author = {
+  name: 'Alice',
+  avatar: 'https://github.com/alice.png',
+  title: 'Frontend Engineer',
+  github: 'https://github.com/alice',
+  x: 'https://x.com/alice',
+};
+
+const authors = [
+  author,
+  {
+    name: 'Bob',
+    avatar: 'https://github.com/bob.png',
+    title: 'Full Stack Engineer',
+    github: 'https://github.com/bob',
+  },
+  {
+    name: 'Charlie',
+    avatar: 'https://github.com/charlie.png',
+    title: 'Tech Lead',
+    x: 'https://x.com/charlie',
+  },
+  {
+    name: 'Dave',
+    avatar: 'https://github.com/dave.png',
+  },
+];
+
+export const BlogAvatarStory = () => (
+  <div style={{ margin: 20 }}>
+    <BlogAvatar author={author} />
+  </div>
+);
+
+export const BlogAvatarGroupStory = () => (
+  <div style={{ margin: 20 }}>
+    <BlogAvatarGroup authors={authors} />
+  </div>
+);
+
+export const BlogAvatarGroupCompactStory = () => (
+  <div style={{ margin: 20 }}>
+    <BlogAvatarGroup authors={authors} compact />
+  </div>
+);
+
+export default {
+  title: 'BlogAvatar',
+};


### PR DESCRIPTION
- Added BlogAvatar Storybook stories (single, group, compact)
- Updated hover/focus color from brand to text-1 (deepest text color)


<img width="1134" height="794" alt="image" src="https://github.com/user-attachments/assets/825dd307-1b4f-442e-8f80-d54fcdc29bd7" />
