### PR TITLE
fix(blog-list): refine blog page presentation

### DIFF
--- a/src/blog-back-button/index.tsx
+++ b/src/blog-back-button/index.tsx
@@ -63,7 +63,9 @@ export function BlogBackButton({
   const Link = LinkComp ?? ALink;
 
   return (
-    <div className={getClassName(styles.blogBackButton, className)}>
+    <div
+      className={getClassName(styles.blogBackButton, 'rp-not-doc', className)}
+    >
       <Link href={blogIndexPath} className={styles.link}>
         {getLabel(lang)}
       </Link>

--- a/src/blog-list/index.module.scss
+++ b/src/blog-list/index.module.scss
@@ -45,6 +45,7 @@
   flex-direction: column;
   border-radius: 24px;
   background: var(--rs-blog-list-card-bg);
+  backdrop-filter: blur(1px);
   border: var(--rs-blog-list-card-border) !important;
   overflow: hidden;
   text-decoration: none !important;
@@ -135,7 +136,7 @@
 
 .clampedDescription {
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 6;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/src/blog-list/index.tsx
+++ b/src/blog-list/index.tsx
@@ -284,7 +284,7 @@ export function BlogList({
   });
 
   return (
-    <div className={getClassName(styles.blogPage, className)}>
+    <div className={getClassName(styles.blogPage, 'rp-not-doc', className)}>
       {title || subtitle ? (
         <header className={styles.header}>
           {title ? <h1 className={styles.pageTitle}>{title}</h1> : null}


### PR DESCRIPTION
## Summary
- add `rp-not-doc` to the blog list wrapper and back button wrapper so they are excluded from doc content styling
- increase blog card description clamp from 3 lines to 6 lines for better preview readability
- add a subtle backdrop blur to blog cards to improve the page presentation

## Testing
- pnpm lint
- pnpm build
