### PR TITLE
fix(BlogList): support arbitrary locale for date formatting

### DIFF
--- a/src/blog-list/index.tsx
+++ b/src/blog-list/index.tsx
@@ -304,7 +304,7 @@ export function BlogList({
 
   const Link = (LinkComp ?? ALink) as (props: LinkLikeProps) => ReactElement;
   const dateFormatter = new Intl.DateTimeFormat(
-    lang === 'zh' ? 'zh-CN' : 'en-US',
+    lang === 'zh' ? 'zh-CN' : lang || 'en-US',
     dateFormatOptions,
   );
   const tiltDisabled = !interactive || isTouchDevice();


### PR DESCRIPTION
### Problem

The BlogList component accepts a `lang` prop, but date formatting ignores it. The locale is hardcoded to either `zh-CN` or `en-US`, so any other language (Russian, German, Japanese, etc.) always renders dates in English format regardless of the `lang` value passed.

### Root cause

In BlogList, the Intl.DateTimeFormat instance is created with a hardcoded locale:

```js
const dateFormatter = new Intl.DateTimeFormat('zh' === lang ? 'zh-CN' : 'en-US', dateFormatOptions);
```

### Fix

Pass `lang` directly to `Intl.DateTimeFormat`, keeping the `zh` → `zh-CN` normalization and falling back to `en-US` only when `lang` is not provided:

```js
const dateFormatter = new Intl.DateTimeFormat(lang === 'zh' ? 'zh-CN' : lang || 'en-US', dateFormatOptions);
```

### Why this is safe

`Intl.DateTimeFormat` accepts any valid BCP 47 language tag. If an unsupported tag is passed, it falls back gracefully. Existing behavior for `zh` and `en` is unchanged.

Fixes #95 