### PR TITLE
chore: build before stage publish

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Build Storybook
         run: pnpm run build-storybook
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dev": "pnpm run storybook",
     "build-storybook": "storybook build",
     "storybook": "storybook dev -p 6006",
-    "prepare": "rslib && simple-git-hooks",
+    "prepare": "simple-git-hooks",
     "build": "rslib",
     "build:watch": "rslib -w",
     "test": "rstest",


### PR DESCRIPTION
## Summary

- Build packages in the release workflow before `pnpm stage publish`.
- Remove duplicate build commands from `scripts.prepare` where present.

## Validation

- Verified staged publish workflows have a preceding `pnpm build`.
- Ran `git diff --check`.