### PR TITLE
fix: should not bundle react

### DIFF
--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -62,13 +62,7 @@ export default defineConfig({
   ],
   output: {
     target: 'web',
-    externals: [
-      'react',
-      'react-dom',
-      'react/jsx-runtime',
-      '@rspress/core',
-      '@rspress/core/runtime',
-    ],
+    externals: [/^react($|\/)/, /^react-dom($|\/)/, /^@rspress\/core($|\/)/],
     filename: {
       js: '[name]/index.js',
       css: '[name]/index.css',


### PR DESCRIPTION
## Summary

This PR fixes the doc-ui library build so React-related subpath imports remain external. The previous exact externals matched `react` and `react-dom`, but allowed `react-dom/client` from the Ant Design wave/render path to be bundled into `dist/antd`, which could conflict with the consuming site's React version.

## Validation

- `pnpm build`
- Verified `dist/antd/index.js` imports `react-dom/client` externally and no longer contains inlined `react-dom@...` version-specific code.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/14293