### PR TITLE
feat(tool-stack): optimize card style with soft shadow and hover lift

### DIFF
--- a/src/tool-stack/index.module.scss
+++ b/src/tool-stack/index.module.scss
@@ -32,28 +32,26 @@
 
 :global {
   html:not(.dark) {
-    --rs-tool-stack-shadow-color: #f9f9f9;
     --rs-tool-stack-title-color: #0b0c0e;
     --rs-tool-stack-desc-color: #8fa1b9;
 
-    --rs-tool-stack-card-stroke: rgba(143, 161, 185, 0.3);
-    --rs-tool-stack-card-gradient: linear-gradient(
-      135deg,
-      rgba(255, 255, 255, 1),
-      rgba(249, 249, 249, 0.5)
-    );
+    --rs-tool-stack-brand: #ff8a00;
+    --rs-tool-stack-card-bg: #fff;
+    --rs-tool-stack-card-shadow: 0 4px 16px
+      color-mix(in srgb, var(--rs-tool-stack-brand) 10%, transparent);
+    --rs-tool-stack-card-shadow-hover:
+      0 12px 24px
+        color-mix(in srgb, var(--rs-tool-stack-brand) 14%, transparent),
+      0 0 16px color-mix(in srgb, var(--rs-tool-stack-brand) 10%, transparent);
     --rs-tools-stack-url-color: #f93920;
   }
   html.dark {
-    --rs-tool-stack-shadow-color: #23272f;
     --rs-tool-stack-title-color: white;
     --rs-tool-stack-desc-color: #8fa1b9;
-    --rs-tool-stack-card-stroke: #23272f;
-    --rs-tool-stack-card-gradient: linear-gradient(
-      135deg,
-      rgba(255, 255, 255, 0),
-      rgba(255, 255, 255, 0.03)
-    );
+    --rs-tool-stack-card-bg: #1b1f27;
+    --rs-tool-stack-card-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+    --rs-tool-stack-card-shadow-hover:
+      0 12px 24px rgba(0, 0, 0, 0.45), 0 0 16px rgba(0, 0, 0, 0.3);
     --rs-tools-stack-url-color: #ff704d;
   }
 }
@@ -77,18 +75,18 @@
 
   flex-direction: column;
   align-items: start;
-  gap: 8px;
+  gap: 16px;
   align-self: stretch;
 
   // style
-  border-radius: 10px;
-  border: 1px solid var(--rs-tool-stack-card-stroke);
-  background: var(--rs-tool-stack-card-gradient);
-  transition: all 0.2s ease-out;
-
-  &:hover {
-    transform: scale3d(1.03, 1.03, 1.03);
-  }
+  border-radius: 16px;
+  background: var(--rs-tool-stack-card-bg);
+  box-shadow: var(--rs-tool-stack-card-shadow);
+  transform: translateY(0) scale(1);
+  transition:
+    transform 0.22s cubic-bezier(0.23, 1, 0.32, 1),
+    box-shadow 0.22s cubic-bezier(0.23, 1, 0.32, 1);
+  will-change: transform, box-shadow;
 
   .logo {
     width: 52px;
@@ -97,22 +95,13 @@
     flex-shrink: 0;
   }
 
-  .toolContent {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-  }
-
   .toolTitle {
     color: var(--rs-tool-stack-title-color);
-    text-align: center;
 
     font-size: 19px;
     font-style: normal;
     font-weight: 600;
     line-height: 24px;
-    margin-top: 4px;
   }
 
   .toolDescription {
@@ -140,8 +129,9 @@
   }
 }
 
-@keyframes rotate {
-  100% {
-    transform: rotate(1turn);
+@media (hover: hover) and (pointer: fine) {
+  .tool:hover {
+    transform: translateY(-5px) scale(1.018);
+    box-shadow: var(--rs-tool-stack-card-shadow-hover);
   }
 }

--- a/src/tool-stack/index.module.scss
+++ b/src/tool-stack/index.module.scss
@@ -43,15 +43,30 @@
       0 12px 24px
         color-mix(in srgb, var(--rs-tool-stack-brand) 14%, transparent),
       0 0 16px color-mix(in srgb, var(--rs-tool-stack-brand) 10%, transparent);
+    --rs-tool-stack-glow-peak: 0.44;
+    --rs-tool-stack-glow-mid: 0.18;
+    --rs-tool-stack-glow-tail: 0.05;
+    --rs-tool-stack-glow-halo-opacity: 0.24;
+    --rs-tool-stack-surface-glow-peak: 6%;
+    --rs-tool-stack-surface-glow-mid: 2%;
+    --rs-tool-stack-surface-glow-radius: 110px;
     --rs-tools-stack-url-color: #f93920;
   }
   html.dark {
     --rs-tool-stack-title-color: white;
     --rs-tool-stack-desc-color: #8fa1b9;
+    --rs-tool-stack-brand: #ff8a00;
     --rs-tool-stack-card-bg: #1b1f27;
     --rs-tool-stack-card-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
     --rs-tool-stack-card-shadow-hover:
       0 12px 24px rgba(0, 0, 0, 0.45), 0 0 16px rgba(0, 0, 0, 0.3);
+    --rs-tool-stack-glow-peak: 0.56;
+    --rs-tool-stack-glow-mid: 0.25;
+    --rs-tool-stack-glow-tail: 0.08;
+    --rs-tool-stack-glow-halo-opacity: 0.32;
+    --rs-tool-stack-surface-glow-peak: 14%;
+    --rs-tool-stack-surface-glow-mid: 4%;
+    --rs-tool-stack-surface-glow-radius: 110px;
     --rs-tools-stack-url-color: #ff704d;
   }
 }
@@ -65,6 +80,7 @@
 }
 
 .tool {
+  position: relative;
   cursor: pointer;
   text-decoration: none;
 
@@ -88,7 +104,38 @@
     box-shadow 0.22s cubic-bezier(0.23, 1, 0.32, 1);
   will-change: transform, box-shadow;
 
+  // pointer-tracked surface glow
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(
+      circle var(--rs-tool-stack-surface-glow-radius) at var(--pointer-x, 50%)
+        var(--pointer-y, 50%),
+      color-mix(
+          in srgb,
+          var(--rs-tool-stack-brand) var(--rs-tool-stack-surface-glow-peak),
+          transparent
+        )
+        0%,
+      color-mix(
+          in srgb,
+          var(--rs-tool-stack-brand) var(--rs-tool-stack-surface-glow-mid),
+          transparent
+        )
+        38%,
+      transparent 72%
+    );
+    opacity: var(--pointer-strength, 0);
+    pointer-events: none;
+    transition: opacity 120ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
   .logo {
+    position: relative;
+    z-index: 1;
     width: 52px;
     height: 52px;
     object-fit: contain;
@@ -96,6 +143,8 @@
   }
 
   .toolTitle {
+    position: relative;
+    z-index: 1;
     color: var(--rs-tool-stack-title-color);
 
     font-size: 19px;
@@ -105,6 +154,8 @@
   }
 
   .toolDescription {
+    position: relative;
+    z-index: 1;
     color: var(--rs-tool-stack-desc-color);
     text-align: left;
     height: 48px;
@@ -117,6 +168,8 @@
   }
 
   .toolUrl {
+    position: relative;
+    z-index: 1;
     color: var(--rs-tools-stack-url-color);
     font-size: 15px;
     font-style: normal;
@@ -127,6 +180,41 @@
     text-align: left;
     width: 100%;
   }
+}
+
+// pointer-tracked edge glow (SVG strokes)
+.edgeGlow {
+  position: absolute;
+  z-index: 2;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 120ms cubic-bezier(0.23, 1, 0.32, 1);
+  will-change: opacity;
+}
+
+.edgeStroke {
+  x: 1px;
+  y: 1px;
+  width: calc(100% - 2px);
+  height: calc(100% - 2px);
+  rx: 15px;
+  ry: 15px;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.edgeHalo {
+  stroke-width: 6px;
+  opacity: var(--rs-tool-stack-glow-halo-opacity);
+}
+
+.edgeLine {
+  stroke-width: 1px;
+  opacity: 1;
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/src/tool-stack/index.tsx
+++ b/src/tool-stack/index.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { memo } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import {
   descStyle,
   innerContainerStyle,
@@ -76,6 +76,79 @@ export const ToolStack: React.FC<{ lang: string }> = memo(({ lang }) => {
     },
   ];
 
+  const toolsRef = useRef<HTMLDivElement>(null);
+  const pointerRef = useRef({ x: 0, y: 0 });
+  const frameRef = useRef(0);
+
+  // Pointer-tracked edge light: updates --pointer-x/y and --pointer-strength
+  // on each card based on the cursor distance, and re-centers each card's
+  // SVG radial gradient on the cursor.
+  useEffect(() => {
+    const grid = toolsRef.current;
+    if (!grid) return;
+    const items = Array.from(grid.children) as HTMLElement[];
+
+    function clearEdgeLight() {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = 0;
+      for (const item of items) {
+        item.style.setProperty('--pointer-strength', '0');
+        const glow = item.querySelector<SVGElement>('svg');
+        if (glow) glow.style.opacity = '0';
+      }
+    }
+
+    function renderEdgeLight() {
+      frameRef.current = 0;
+      const { x: pointerX, y: pointerY } = pointerRef.current;
+
+      for (const item of items) {
+        const rect = item.getBoundingClientRect();
+        const dx = Math.max(rect.left - pointerX, 0, pointerX - rect.right);
+        const dy = Math.max(rect.top - pointerY, 0, pointerY - rect.bottom);
+        const distance = Math.hypot(dx, dy);
+        const strength = Math.max(0, 1 - distance / 120);
+        const glow = item.querySelector<SVGElement>('svg');
+        const gradient =
+          item.querySelector<SVGRadialGradientElement>('radialGradient');
+        if (!glow || !gradient) return;
+
+        const localX = (pointerX - rect.left).toFixed(1);
+        const localY = (pointerY - rect.top).toFixed(1);
+        gradient.setAttribute('cx', localX);
+        gradient.setAttribute('cy', localY);
+        item.style.setProperty('--pointer-x', `${localX}px`);
+        item.style.setProperty('--pointer-y', `${localY}px`);
+        item.style.setProperty('--pointer-strength', strength.toFixed(3));
+        glow.style.opacity = strength.toFixed(3);
+      }
+    }
+
+    function updateEdgeLight(event: PointerEvent) {
+      if (!window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+        clearEdgeLight();
+        return;
+      }
+      pointerRef.current = { x: event.clientX, y: event.clientY };
+      if (!frameRef.current) {
+        frameRef.current = requestAnimationFrame(renderEdgeLight);
+      }
+    }
+
+    window.addEventListener('pointermove', updateEdgeLight, { passive: true });
+    window.addEventListener('blur', clearEdgeLight);
+    document.documentElement.addEventListener('pointerleave', clearEdgeLight);
+    return () => {
+      cancelAnimationFrame(frameRef.current);
+      window.removeEventListener('pointermove', updateEdgeLight);
+      window.removeEventListener('blur', clearEdgeLight);
+      document.documentElement.removeEventListener(
+        'pointerleave',
+        clearEdgeLight,
+      );
+    };
+  }, []);
+
   return (
     <div className={innerContainerStyle}>
       <div className={titleAndDescStyle}>
@@ -86,8 +159,10 @@ export const ToolStack: React.FC<{ lang: string }> = memo(({ lang }) => {
             : '高性能、一体化的 JavaScript 工具链，为开发者与 Agent 打造'}
         </p>
       </div>
-      <div className={styles.tools}>
+      <div className={styles.tools} ref={toolsRef}>
         {tools.map(({ name, desc, logo, url, urlText }) => {
+          const gradientId = `rs-tool-stack-edge-gradient-${name}`;
+          const blurId = `rs-tool-stack-edge-blur-${name}`;
           return (
             <a
               target="_blank"
@@ -105,6 +180,60 @@ export const ToolStack: React.FC<{ lang: string }> = memo(({ lang }) => {
               <div className={styles.toolTitle}>{name}</div>
               <p className={styles.toolDescription}>{desc}</p>
               <div className={styles.toolUrl}>{urlText}</div>
+              <svg
+                className={styles.edgeGlow}
+                aria-hidden="true"
+                focusable="false"
+              >
+                <defs>
+                  <radialGradient
+                    id={gradientId}
+                    gradientUnits="userSpaceOnUse"
+                    cx="0"
+                    cy="0"
+                    r="130"
+                  >
+                    <stop
+                      offset="0"
+                      stopColor="var(--rs-tool-stack-brand)"
+                      stopOpacity="var(--rs-tool-stack-glow-peak)"
+                    />
+                    <stop
+                      offset="0.32"
+                      stopColor="var(--rs-tool-stack-brand)"
+                      stopOpacity="var(--rs-tool-stack-glow-mid)"
+                    />
+                    <stop
+                      offset="0.62"
+                      stopColor="var(--rs-tool-stack-brand)"
+                      stopOpacity="var(--rs-tool-stack-glow-tail)"
+                    />
+                    <stop
+                      offset="1"
+                      stopColor="var(--rs-tool-stack-brand)"
+                      stopOpacity="0"
+                    />
+                  </radialGradient>
+                  <filter
+                    id={blurId}
+                    x="-40%"
+                    y="-70%"
+                    width="180%"
+                    height="240%"
+                  >
+                    <feGaussianBlur stdDeviation="3.5" />
+                  </filter>
+                </defs>
+                <rect
+                  className={`${styles.edgeStroke} ${styles.edgeHalo}`}
+                  stroke={`url(#${gradientId})`}
+                  filter={`url(#${blurId})`}
+                />
+                <rect
+                  className={`${styles.edgeStroke} ${styles.edgeLine}`}
+                  stroke={`url(#${gradientId})`}
+                />
+              </svg>
             </a>
           );
         })}

--- a/src/tool-stack/index.tsx
+++ b/src/tool-stack/index.tsx
@@ -92,7 +92,7 @@ export const ToolStack: React.FC<{ lang: string }> = memo(({ lang }) => {
             <a
               target="_blank"
               rel="noreferrer"
-              className={[styles.tool, styles.rainbow].join(' ')}
+              className={styles.tool}
               key={name}
               href={url}
             >


### PR DESCRIPTION
## Summary

Optimize the `ToolStack` card style, referencing the card design of the Doubao Apps documentation site (`theme/home/HomeFeatures.tsx` + `home.css`).

Before: cards used a 1px stroke + subtle gradient background, and hover only applied a simple `scale(1.03)` zoom.

After:

- **Soft floating card**: white (dark: `#1b1f27`) surface with a soft brand-tinted shadow (`color-mix` with `--rs-tool-stack-brand: #ff8a00`) instead of border + gradient.
- **Larger radius**: `border-radius` increased from `10px` to `16px`.
- **Smoother hover**: `translateY(-5px) scale(1.018)` with a stronger shadow, using `220ms cubic-bezier(0.23, 1, 0.32, 1)` easing.
- **Pointer-tracked glow** (same mechanism as the Doubao cards):
  - Window-level `pointermove` listener, throttled with `requestAnimationFrame`, computes a per-card glow strength from the cursor's distance to each card — so cards near the cursor light up too, not just the hovered one.
  - Each card renders an SVG edge glow: a blurred 6px halo stroke + a crisp 1px line stroke, both using a `radialGradient` (`userSpaceOnUse`) that is re-centered on the cursor every frame.
  - A `::before` surface glow (radial gradient, radius 110px) follows the pointer inside the card.
  - Respects `@media (hover: hover) and (pointer: fine)` (no sticky hover/glow on touch); glow state is cleared on window `blur` and document `pointerleave`.
  - Dark mode gets stronger glow opacities (peak 0.56 vs 0.44, surface 14% vs 6%).
- **Cleanup**: removed the dead `styles.rainbow` class reference (no such class existed), the unused `.toolContent` style, and the orphaned `@keyframes rotate`.

## Test Plan

- [x] `pnpm build` passes
- [x] `pnpm lint` (rslint + prettier) passes
- [ ] Visual check via Storybook (`ToolStack` story) / Chromatic
