### PR TITLE
chore: rename package to @rstackjs/doc-ui

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Shared UI component library (`@rstack-dev/doc-ui`) for Rstack websites (rspack.rs, rsbuild.rs, rspress.rs).
+Shared UI component library (`@rstackjs/doc-ui`) for Rstack websites (rspack.rs, rsbuild.rs, rspress.rs).
 
 ## Tech Stack
 
@@ -144,7 +144,7 @@ export const MyComponent: FC<MyComponentProps> = ({
 
 ```typescript
 // stories/Hero.stories.tsx
-import { Hero } from '@rstack-dev/doc-ui/hero';
+import { Hero } from '@rstackjs/doc-ui/hero';
 import './index.scss';
 
 export const HeroStory = () => <Hero onClickGetStarted={() => {}} />;

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Shared UI components for the Rstack websites.
 
+> [!IMPORTANT]
+> The package has been renamed from `@rstack-dev/doc-ui` to
+> `@rstackjs/doc-ui`. Update dependencies and imports to use the new package
+> name, including subpath imports such as `@rstackjs/doc-ui/hero`.
+
 - <http://rspack.rs>
 - <http://rsbuild.rs>
 - <http://rspress.rs>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Shared UI components for the Rstack websites.
 
 > [!IMPORTANT]
 > The package has been renamed from `@rstack-dev/doc-ui` to
-> `@rstackjs/doc-ui`. Update dependencies and imports to use the new package
-> name, including subpath imports such as `@rstackjs/doc-ui/hero`.
+> `@rstackjs/doc-ui`.
 
 - <http://rspack.rs>
 - <http://rsbuild.rs>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rstack-dev/doc-ui",
+  "name": "@rstackjs/doc-ui",
   "version": "1.14.8",
   "type": "module",
   "license": "MIT",
@@ -100,7 +100,7 @@
     "@rslib/core": "^0.23.2",
     "@rslint/core": "^0.8.0",
     "@rspress/core": "^2.0.19",
-    "@rstack-dev/doc-ui": "workspace:*",
+    "@rstackjs/doc-ui": "workspace:*",
     "@rstest/adapter-rslib": "^0.11.8",
     "@rstest/core": "^0.11.8",
     "@storybook/addon-themes": "^10.5.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
       '@rspress/core':
         specifier: ^2.0.19
         version: 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(supports-color@8.1.1)
-      '@rstack-dev/doc-ui':
+      '@rstackjs/doc-ui':
         specifier: workspace:*
         version: 'link:'
       '@rstest/adapter-rslib':

--- a/stories/Announcement.stories.tsx
+++ b/stories/Announcement.stories.tsx
@@ -1,4 +1,4 @@
-import { Announcement } from '@rstack-dev/doc-ui/announcement';
+import { Announcement } from '@rstackjs/doc-ui/announcement';
 import './index.scss';
 
 export const AnnouncementStory = () => (

--- a/stories/Benchmark.stories.tsx
+++ b/stories/Benchmark.stories.tsx
@@ -1,4 +1,4 @@
-import { Benchmark } from '@rstack-dev/doc-ui/benchmark';
+import { Benchmark } from '@rstackjs/doc-ui/benchmark';
 import './index.scss';
 
 // Benchmark data for different cases

--- a/stories/BlogAuthors.stories.tsx
+++ b/stories/BlogAuthors.stories.tsx
@@ -1,5 +1,5 @@
-import { BlogBackButton } from '@rstack-dev/doc-ui/blog-back-button';
-import { BlogAuthors } from '@rstack-dev/doc-ui/blog-authors';
+import { BlogBackButton } from '@rstackjs/doc-ui/blog-back-button';
+import { BlogAuthors } from '@rstackjs/doc-ui/blog-authors';
 import { PageContext } from '@rspress/core/runtime';
 import './index.scss';
 

--- a/stories/BlogAvatar.stories.tsx
+++ b/stories/BlogAvatar.stories.tsx
@@ -2,7 +2,7 @@ import {
   BlogAvatar,
   BlogAvatarGroup,
   type BlogAvatarAuthor,
-} from '@rstack-dev/doc-ui/blog-avatar';
+} from '@rstackjs/doc-ui/blog-avatar';
 import './index.scss';
 
 const author: BlogAvatarAuthor = {

--- a/stories/BlogBackButton.stories.tsx
+++ b/stories/BlogBackButton.stories.tsx
@@ -1,4 +1,4 @@
-import { BlogBackButton } from '@rstack-dev/doc-ui/blog-back-button';
+import { BlogBackButton } from '@rstackjs/doc-ui/blog-back-button';
 import type { ReactNode } from 'react';
 import './index.scss';
 

--- a/stories/BlogList.stories.tsx
+++ b/stories/BlogList.stories.tsx
@@ -1,6 +1,6 @@
-import type { BlogAvatarAuthor } from '@rstack-dev/doc-ui/blog-avatar';
-import { BlogBackground } from '@rstack-dev/doc-ui/blog-background';
-import { BlogList, type BlogListItem } from '@rstack-dev/doc-ui/blog-list';
+import type { BlogAvatarAuthor } from '@rstackjs/doc-ui/blog-avatar';
+import { BlogBackground } from '@rstackjs/doc-ui/blog-background';
+import { BlogList, type BlogListItem } from '@rstackjs/doc-ui/blog-list';
 import type { ReactNode } from 'react';
 import './index.scss';
 

--- a/stories/BuiltWithRspack.stories.tsx
+++ b/stories/BuiltWithRspack.stories.tsx
@@ -1,5 +1,5 @@
-import type { Company } from '@rstack-dev/doc-ui/built-with-rspack';
-import { BuiltWithRspack } from '@rstack-dev/doc-ui/built-with-rspack';
+import type { Company } from '@rstackjs/doc-ui/built-with-rspack';
+import { BuiltWithRspack } from '@rstackjs/doc-ui/built-with-rspack';
 import './index.scss';
 import amazonLogo from './assets/amazon.svg';
 import bitDevLogo from './assets/bit.svg';

--- a/stories/FullyFeatured.stories.tsx
+++ b/stories/FullyFeatured.stories.tsx
@@ -1,4 +1,4 @@
-import { type Feature, FullyFeatured } from '@rstack-dev/doc-ui/fully-featured';
+import { type Feature, FullyFeatured } from '@rstackjs/doc-ui/fully-featured';
 import './index.scss';
 import arrow from './assets/arrow.svg';
 

--- a/stories/Hero.stories.tsx
+++ b/stories/Hero.stories.tsx
@@ -1,5 +1,5 @@
-import { BackgroundImage } from '@rstack-dev/doc-ui/background-image';
-import { Hero } from '@rstack-dev/doc-ui/hero';
+import { BackgroundImage } from '@rstackjs/doc-ui/background-image';
+import { Hero } from '@rstackjs/doc-ui/hero';
 import './index.scss';
 
 export const HeroStory = () => {

--- a/stories/NavIcon.stories.tsx
+++ b/stories/NavIcon.stories.tsx
@@ -1,4 +1,4 @@
-import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
+import { NavIcon } from '@rstackjs/doc-ui/nav-icon';
 import { userEvent, within } from '@storybook/test';
 import './index.scss';
 

--- a/stories/SectionStyle.stories.tsx
+++ b/stories/SectionStyle.stories.tsx
@@ -4,7 +4,7 @@ import {
   innerContainerStyle,
   titleAndDescStyle,
   titleStyle,
-} from '@rstack-dev/doc-ui/section-style';
+} from '@rstackjs/doc-ui/section-style';
 import './index.scss';
 
 const sections = [

--- a/stories/ToolStack.stories.tsx
+++ b/stories/ToolStack.stories.tsx
@@ -1,4 +1,4 @@
-import { ToolStack } from '@rstack-dev/doc-ui/tool-stack';
+import { ToolStack } from '@rstackjs/doc-ui/tool-stack';
 import './index.scss';
 
 export const ToolStackStory = () => (

--- a/stories/WhyRspack.stories.tsx
+++ b/stories/WhyRspack.stories.tsx
@@ -1,8 +1,8 @@
 import {
   containerStyle,
   innerContainerStyle,
-} from '@rstack-dev/doc-ui/section-style';
-import { type Feature, WhyRspack } from '@rstack-dev/doc-ui/why-rspack';
+} from '@rstackjs/doc-ui/section-style';
+import { type Feature, WhyRspack } from '@rstackjs/doc-ui/why-rspack';
 import './index.scss';
 import CompatibleJson from './why-rspack-assets/Compatible.json';
 import Compatible from './why-rspack-assets/Compatible.svg';


### PR DESCRIPTION
This PR moves the published package from `@rstack-dev/doc-ui` to the canonical `@rstackjs/doc-ui` scope.

It updates the package metadata, workspace self-reference, lockfile, Storybook imports, README migration guidance, and contributor documentation to use the new name. Consumers must update imports from `@rstack-dev/doc-ui/*` to `@rstackjs/doc-ui/*`.