### PR TITLE
feat: export shared Rspress theme styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "./blog-background": {
       "types": "./dist/blog-background/index.d.ts",
       "import": "./dist/blog-background/index.js"
-    }
+    },
+    "./theme.css": "./dist/theme/index.css"
   },
   "repository": {
     "type": "git",

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -59,6 +59,13 @@ export default defineConfig({
         },
       },
     },
+    {
+      source: {
+        entry: {
+          theme: './src/theme.scss',
+        },
+      },
+    },
   ],
   output: {
     target: 'web',

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -1,0 +1,71 @@
+:root {
+  --rp-c-brand: #ff5e00;
+  --rp-c-brand-dark: var(--rp-c-brand);
+  --rp-c-brand-darker: #ff704d;
+  --rp-c-brand-light: #ff7524;
+  --rp-c-brand-lighter: #ff7524;
+  --rp-c-brand-tint: rgba(255, 94, 0, 0.07);
+  --rp-c-text-code: var(--rp-c-text-1);
+}
+
+.dark {
+  --rp-c-link: var(--rp-c-brand-light);
+}
+
+html:not(.dark) {
+  --rp-c-text-2: #666;
+}
+
+.rp-sidebar-item:hover,
+.rp-sidebar-item--active,
+.rp-sidebar-item--active:hover {
+  color: var(--rp-c-text-0);
+  background-color: var(--rp-c-bg-mute);
+}
+
+.dark {
+  .rp-sidebar-item:hover,
+  .rp-sidebar-item--active,
+  .rp-sidebar-item--active:hover {
+    background-color: #1f1f1f;
+  }
+}
+
+.rp-toc-item__text,
+.rp-toc-item__text code {
+  color: var(--rp-c-text-2);
+}
+
+.rp-toc-item--active .rp-toc-item__text,
+.rp-toc-item--active .rp-toc-item__text code {
+  color: var(--rp-c-text-0);
+  font-weight: 500;
+}
+
+.rp-doc {
+  .rp-link,
+  .rp-link code {
+    color: inherit;
+    text-decoration-line: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: rgba(0, 0, 0, 0.25);
+
+    &:hover {
+      opacity: 1;
+      text-decoration-color: currentColor;
+      border-bottom: none !important;
+    }
+  }
+}
+
+.dark {
+  .rp-doc {
+    .rp-link {
+      text-decoration-color: rgba(255, 255, 255, 0.5);
+
+      &:hover {
+        text-decoration-color: currentColor;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR centralizes the shared Rspress theme styles in `@rstackjs/doc-ui` so Rstack documentation sites can reuse a consistent theme. It adds the SCSS file as a dedicated Rslib entry and exports the compiled stylesheet as `@rstackjs/doc-ui/theme.css`.