### PR TITLE
fix: only underline overview links on hover

### DIFF
--- a/src/theme.scss
+++ b/src/theme.scss
@@ -58,6 +58,19 @@ html:not(.dark) {
   }
 }
 
+// OverviewGroup is a card-style navigation list, so only underline links on hover.
+.rp-overview-group {
+  .rp-link,
+  .rp-link code {
+    text-decoration-line: none;
+  }
+
+  .rp-link:hover,
+  .rp-link:hover code {
+    text-decoration-line: underline;
+  }
+}
+
 .dark {
   .rp-doc {
     .rp-link {


### PR DESCRIPTION
OverviewGroup renders links inside card-style navigation, where always-visible underlines add unnecessary visual noise.

This PR adds a shared theme override so OverviewGroup links are undecorated by default and underlined on hover, including inline code content.