### PR TITLE
chore: use pnpm version for releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "build": "rs lib",
     "build:watch": "rs lib -w",
     "build-storybook": "storybook build",
-    "bump": "npx bumpp",
+    "bump": "pnpm version -m \"release: v%s\"",
     "check": "rs check",
     "chromatic": "chromatic",
     "dev": "pnpm run storybook",


### PR DESCRIPTION
## Summary

Use pnpm's built-in version command for release preparation, matching rspack-vue-loader. Replace `npx bumpp` with `pnpm version -m "release: v%s"` to create version commits with the standard release message.